### PR TITLE
Update autoconfig.settings.sample.php

### DIFF
--- a/src/autoconfig.settings.sample.php
+++ b/src/autoconfig.settings.sample.php
@@ -16,7 +16,7 @@ $cfg->name = 'Example mail services';
 $cfg->nameShort = 'Example';
 
 // Domains for which these settings apply, in lowercase.
-$cfg->domains = [ 'example.com', 'example.net', 'example.org' ];
+$cfg->domains = array( 'example.com', 'example.net', 'example.org' );
 
 // This is the username associated with the email address. If some kind of lookup
 // needs to occur to map the email address to a username, this can be done by


### PR DESCRIPTION
When reduced to a single domain PHP will error because of unexpected ] in line 19 and the base file is annoyed at line 15 of the missing array. $cfg->domains = array( 'example.com', 'example.net', 'example.org' ); and $cfg->domains = array( 'example.com' ); are valid arrays.
Thx for the Project, works like a charm.